### PR TITLE
[FEAT] 메인 뱃지 변경 기능 

### DIFF
--- a/modules/domain/src/main/java/com/whoz_in/domain/badge/exception/BadgeNotOwnedByMemberException.java
+++ b/modules/domain/src/main/java/com/whoz_in/domain/badge/exception/BadgeNotOwnedByMemberException.java
@@ -1,0 +1,8 @@
+package com.whoz_in.domain.badge.exception;
+
+import com.whoz_in.shared.WhozinException;
+
+public class BadgeNotOwnedByMemberException extends WhozinException {
+    public static final BadgeNotOwnedByMemberException EXCEPTION = new BadgeNotOwnedByMemberException();
+    private BadgeNotOwnedByMemberException() {super("5007", "가지고 있지 않은 뱃지입니다.");}
+}

--- a/modules/domain/src/main/java/com/whoz_in/domain/member/model/Member.java
+++ b/modules/domain/src/main/java/com/whoz_in/domain/member/model/Member.java
@@ -5,7 +5,6 @@ import com.whoz_in.domain.badge.exception.BadgeCurrentHidedException;
 import com.whoz_in.domain.badge.exception.BadgeNotOwnedByMemberException;
 import com.whoz_in.domain.badge.model.BadgeId;
 import com.whoz_in.domain.shared.AggregateRoot;
-import com.whoz_in.shared.domain_event.member.MemberBadgeVisibilityChanged;
 import com.whoz_in.shared.domain_event.member.MemberCreated;
 import com.whoz_in.shared.domain_event.member.MemberStatusMessageChanged;
 import java.util.Collections;
@@ -89,7 +88,6 @@ public final class Member extends AggregateRoot {
 
     public void changeBadgeVisibility(BadgeId badgeId, boolean show) {
         this.badges.put(badgeId, show);
-        this.register(new MemberBadgeVisibilityChanged(this.getId().id().toString(), badgeId.id().toString(), show));
     }
 
     public void attachBadge(BadgeId badgeId) {

--- a/modules/domain/src/main/java/com/whoz_in/domain/member/model/Member.java
+++ b/modules/domain/src/main/java/com/whoz_in/domain/member/model/Member.java
@@ -2,7 +2,7 @@ package com.whoz_in.domain.member.model;
 
 
 import com.whoz_in.domain.badge.exception.BadgeCurrentHidedException;
-import com.whoz_in.domain.badge.exception.NoBadgeException;
+import com.whoz_in.domain.badge.exception.BadgeNotOwnedByMemberException;
 import com.whoz_in.domain.badge.model.BadgeId;
 import com.whoz_in.domain.shared.AggregateRoot;
 import com.whoz_in.shared.domain_event.member.MemberBadgeVisibilityChanged;
@@ -102,7 +102,7 @@ public final class Member extends AggregateRoot {
 
     public void changeMainBadge(BadgeId badgeId) {
         if (!badges.containsKey(badgeId)) {
-            throw NoBadgeException.EXCEPTION;
+            throw BadgeNotOwnedByMemberException.EXCEPTION;
         }
         if (!badges.get(badgeId)) {
             throw BadgeCurrentHidedException.EXCEPTION;

--- a/modules/infrastructure/infra-jpa/src/main/java/com/whoz_in_infra/infra_jpa/domain/member/MemberConverter.java
+++ b/modules/infrastructure/infra-jpa/src/main/java/com/whoz_in_infra/infra_jpa/domain/member/MemberConverter.java
@@ -36,7 +36,7 @@ public class MemberConverter extends BaseConverter<MemberEntity, Member> {
                 oAuth.getSocialId(),
                 mainBadge != null ? member.getMainBadge().id() : null,
                 badgeMembers,
-                member.getProfileImageId().id()
+                member.getProfileImageId() != null ? member.getProfileImageId().id() : null
         );
     }
 
@@ -56,7 +56,7 @@ public class MemberConverter extends BaseConverter<MemberEntity, Member> {
                 OAuthCredentials.create(entity.getSocialProvider(), entity.getSocialId()),
                 badges,
                 new BadgeId(entity.getMainBadge()),
-                new ProfileImageId(entity.getProfile_image_id())
+                entity.getProfile_image_id() != null ? new ProfileImageId(entity.getProfile_image_id()) : null
         );
     }
 }

--- a/modules/main-api/src/main/java/com/whoz_in/main_api/command/badge/application/BadgeSwitchVisibilityHandler.java
+++ b/modules/main-api/src/main/java/com/whoz_in/main_api/command/badge/application/BadgeSwitchVisibilityHandler.java
@@ -26,7 +26,6 @@ public class BadgeSwitchVisibilityHandler implements CommandHandler<BadgeSwitchV
         Member member = repository.findByMemberId(requesterId).orElseThrow(()-> NoMemberException.EXCEPTION);
         member.changeBadgeVisibility(new BadgeId(req.badgeId()), req.show());
         repository.save(member);
-        eventBus.publish(member.pullDomainEvents());
         return null;
     }
 }

--- a/modules/main-api/src/main/java/com/whoz_in/main_api/command/badge/application/MainBadgeChange.java
+++ b/modules/main-api/src/main/java/com/whoz_in/main_api/command/badge/application/MainBadgeChange.java
@@ -1,0 +1,7 @@
+package com.whoz_in.main_api.command.badge.application;
+
+import com.whoz_in.main_api.command.shared.application.Command;
+import java.util.UUID;
+
+public record MainBadgeChange(UUID badgeId) implements Command {
+}

--- a/modules/main-api/src/main/java/com/whoz_in/main_api/command/badge/application/MainBadgeChangeHandler.java
+++ b/modules/main-api/src/main/java/com/whoz_in/main_api/command/badge/application/MainBadgeChangeHandler.java
@@ -1,0 +1,29 @@
+package com.whoz_in.main_api.command.badge.application;
+
+import com.whoz_in.domain.badge.model.BadgeId;
+import com.whoz_in.domain.member.MemberRepository;
+import com.whoz_in.domain.member.exception.NoMemberException;
+import com.whoz_in.domain.member.model.Member;
+import com.whoz_in.domain.member.model.MemberId;
+import com.whoz_in.main_api.command.shared.application.CommandHandler;
+import com.whoz_in.main_api.shared.application.Handler;
+import com.whoz_in.main_api.shared.utils.RequesterInfo;
+import lombok.RequiredArgsConstructor;
+import org.springframework.transaction.annotation.Transactional;
+
+@Handler
+@RequiredArgsConstructor
+public class MainBadgeChangeHandler implements CommandHandler<MainBadgeChange, Void> {
+    private final RequesterInfo requesterInfo;
+    private final MemberRepository repository;
+
+    @Transactional
+    @Override
+    public Void handle(MainBadgeChange req) {
+        MemberId requesterId = requesterInfo.getMemberId();
+        Member member = repository.findByMemberId(requesterId).orElseThrow(()-> NoMemberException.EXCEPTION);
+        member.changeMainBadge(new BadgeId(req.badgeId()));
+        repository.save(member);
+        return null;
+    }
+}

--- a/modules/main-api/src/main/java/com/whoz_in/main_api/command/badge/application/MainBadgeChangeHandler.java
+++ b/modules/main-api/src/main/java/com/whoz_in/main_api/command/badge/application/MainBadgeChangeHandler.java
@@ -1,6 +1,8 @@
 package com.whoz_in.main_api.command.badge.application;
 
+import com.whoz_in.domain.badge.model.Badge;
 import com.whoz_in.domain.badge.model.BadgeId;
+import com.whoz_in.domain.badge.service.BadgeFinderService;
 import com.whoz_in.domain.member.MemberRepository;
 import com.whoz_in.domain.member.exception.NoMemberException;
 import com.whoz_in.domain.member.model.Member;
@@ -16,13 +18,15 @@ import org.springframework.transaction.annotation.Transactional;
 public class MainBadgeChangeHandler implements CommandHandler<MainBadgeChange, Void> {
     private final RequesterInfo requesterInfo;
     private final MemberRepository repository;
+    private final BadgeFinderService badgeFinderService;
 
     @Transactional
     @Override
     public Void handle(MainBadgeChange req) {
         MemberId requesterId = requesterInfo.getMemberId();
         Member member = repository.findByMemberId(requesterId).orElseThrow(()-> NoMemberException.EXCEPTION);
-        member.changeMainBadge(new BadgeId(req.badgeId()));
+        Badge badge = badgeFinderService.find(new BadgeId(req.badgeId()));
+        member.changeMainBadge(badge.getId());
         repository.save(member);
         return null;
     }

--- a/modules/main-api/src/main/java/com/whoz_in/main_api/command/badge/presentation/BadgeCommandController.java
+++ b/modules/main-api/src/main/java/com/whoz_in/main_api/command/badge/presentation/BadgeCommandController.java
@@ -3,6 +3,7 @@ package com.whoz_in.main_api.command.badge.presentation;
 import com.whoz_in.main_api.command.badge.application.BadgeAttach;
 import com.whoz_in.main_api.command.badge.application.BadgeRegister;
 import com.whoz_in.main_api.command.badge.application.BadgeSwitchVisibility;
+import com.whoz_in.main_api.command.badge.application.MainBadgeChange;
 import com.whoz_in.main_api.command.badge.presentation.docs.BadgeCommandApi;
 import com.whoz_in.main_api.command.shared.application.CommandBus;
 import com.whoz_in.main_api.command.shared.presentation.CommandController;
@@ -40,5 +41,12 @@ public class BadgeCommandController extends CommandController implements BadgeCo
     public ResponseEntity<SuccessBody<Void>> update(@RequestBody BadgeSwitchVisibility request) {
         dispatch(request);
         return ResponseEntityGenerator.success( "뱃지 보여주기 또는 숨기기 변환 완료", HttpStatus.OK);
+    }
+
+    @Override
+    @PatchMapping("/badges/main")
+    public ResponseEntity<SuccessBody<Void>> changeMainBadge(@RequestBody MainBadgeChange request) {
+        dispatch(request);
+        return ResponseEntityGenerator.success("메인 뱃지 변경 완료", HttpStatus.OK);
     }
 }

--- a/modules/main-api/src/main/java/com/whoz_in/main_api/command/badge/presentation/docs/BadgeCommandApi.java
+++ b/modules/main-api/src/main/java/com/whoz_in/main_api/command/badge/presentation/docs/BadgeCommandApi.java
@@ -3,6 +3,7 @@ package com.whoz_in.main_api.command.badge.presentation.docs;
 import com.whoz_in.main_api.command.badge.application.BadgeAttach;
 import com.whoz_in.main_api.command.badge.application.BadgeRegister;
 import com.whoz_in.main_api.command.badge.application.BadgeSwitchVisibility;
+import com.whoz_in.main_api.command.badge.application.MainBadgeChange;
 import com.whoz_in.main_api.shared.presentation.response.SuccessBody;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.tags.Tag;
@@ -29,4 +30,10 @@ public interface BadgeCommandApi {
             description = "사용자는 뱃지를 보여주고 숨김으로써 자신의 뱃지 조회 상태를 관리할 수 있습니다."
     )
     ResponseEntity<SuccessBody<Void>> update(@RequestBody BadgeSwitchVisibility request);
+
+    @Operation(
+            summary = "메인 뱃지 변경",
+            description = "사용자는 자신의 메인 뱃지를 변경합니다."
+    )
+    ResponseEntity<SuccessBody<Void>> changeMainBadge(@RequestBody MainBadgeChange request);
 }

--- a/modules/main-api/src/main/java/com/whoz_in/main_api/config/security/SecurityFilterChainConfig.java
+++ b/modules/main-api/src/main/java/com/whoz_in/main_api/config/security/SecurityFilterChainConfig.java
@@ -169,7 +169,8 @@ public class SecurityFilterChainConfig {
                         "/api/v1/members/images"
                 ).requestMatchers(HttpMethod.PATCH,
                         "/api/v1/device/info",
-                        "/api/v1/badges/members"
+                        "/api/v1/badges/members",
+                        "/api/v1/badges/main"
                 ).requestMatchers(HttpMethod.DELETE,
                         "/api/v1/device"
                 )


### PR DESCRIPTION
## 📌 관련 이슈

close #336 

## ✨ PR 내용

대표 뱃지 변경 API를 구현했습니다.

## 🤓 리뷰어에게



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- 신규 기능
  - 메인 뱃지 변경 지원: PATCH /api/v1/badges/main 엔드포인트 추가로 사용자가 자신의 메인 뱃지를 설정할 수 있습니다.
- 보안
  - /api/v1/badges/main 엔드포인트에 인증이 요구됩니다.
- 버그 수정
  - 프로필 이미지 ID의 null 안전성 개선으로 간헐적 프로필 로드 오류를 예방했습니다.
- 문서
  - API 문서에 “메인 뱃지 변경” 엔드포인트와 설명을 추가했습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->