### PR TITLE
[FEAT] 프로필 이미지 조회 + 삭제(기본 프로필 이미지 적용)

### DIFF
--- a/modules/domain/src/main/java/com/whoz_in/domain/member/model/Member.java
+++ b/modules/domain/src/main/java/com/whoz_in/domain/member/model/Member.java
@@ -115,4 +115,8 @@ public final class Member extends AggregateRoot {
             this.profileImageId = new ProfileImageId();
         }
     }
+
+    public void setDefaultProfileImage() {
+        this.profileImageId = null;
+    }
 }

--- a/modules/infrastructure/infra-jpa/src/main/java/com/whoz_in_infra/infra_jpa/domain/member/MemberConverter.java
+++ b/modules/infrastructure/infra-jpa/src/main/java/com/whoz_in_infra/infra_jpa/domain/member/MemberConverter.java
@@ -36,7 +36,7 @@ public class MemberConverter extends BaseConverter<MemberEntity, Member> {
                 oAuth.getSocialId(),
                 mainBadge != null ? member.getMainBadge().id() : null,
                 badgeMembers,
-                member.getProfileImageId().id()
+                member.getProfileImageId() != null ? member.getProfileImageId().id() : null
         );
     }
 
@@ -56,7 +56,7 @@ public class MemberConverter extends BaseConverter<MemberEntity, Member> {
                 OAuthCredentials.create(entity.getSocialProvider(), entity.getSocialId()),
                 badges,
                 new BadgeId(entity.getMainBadge()),
-                new ProfileImageId(entity.getProfile_image_id())
+                entity.getProfile_image_id() != null ? new ProfileImageId(entity.getProfile_image_id()) : null
         );
     }
 }

--- a/modules/infrastructure/infra-jpa/src/main/java/com/whoz_in_infra/infra_jpa/query/member/Member.java
+++ b/modules/infrastructure/infra-jpa/src/main/java/com/whoz_in_infra/infra_jpa/query/member/Member.java
@@ -29,7 +29,8 @@ import org.hibernate.annotations.UuidGenerator;
         + "b.id AS main_badge_id, "
         + "b.name AS main_badge_name, "
         + "b.color_string AS main_badge_color, "
-        + "a.active_time AS total_active_time "
+        + "a.active_time AS total_active_time, "
+        + "m.profile_image_id "
         + "FROM member_entity m "
         + "LEFT JOIN badge_entity b ON m.main_badge = b.id "
         + "LEFT JOIN activity_history a ON m.id = a.member_id AND a.time_unit = 'TOTAL'"
@@ -65,6 +66,9 @@ public class Member {
 
     @Column(name = "total_active_time")
     private Duration totalActiveTime;
+
+    @Column(name = "profile_image_id")
+    private UUID profileImageId;
 
     /**
      * {@link YesterdayActivityRecorder}가

--- a/modules/infrastructure/infra-jpa/src/main/java/com/whoz_in_infra/infra_jpa/query/member/MemberInfoJpaViewer.java
+++ b/modules/infrastructure/infra-jpa/src/main/java/com/whoz_in_infra/infra_jpa/query/member/MemberInfoJpaViewer.java
@@ -40,7 +40,8 @@ public class MemberInfoJpaViewer implements MemberInfoViewer {
                                 .orElse(Duration.ZERO)
                 ),
                 entity.getMainBadgeName(),
-                entity.getMainBadgeColor()
+                entity.getMainBadgeColor(),
+                entity.getProfileImageId()
         );
     }
 

--- a/modules/main-api/src/main/java/com/whoz_in/main_api/command/member/application/ProfileImageDelete.java
+++ b/modules/main-api/src/main/java/com/whoz_in/main_api/command/member/application/ProfileImageDelete.java
@@ -1,0 +1,6 @@
+package com.whoz_in.main_api.command.member.application;
+
+import com.whoz_in.main_api.command.shared.application.Command;
+
+public record ProfileImageDelete() implements Command {
+}

--- a/modules/main-api/src/main/java/com/whoz_in/main_api/command/member/application/ProfileImageDeleteHandler.java
+++ b/modules/main-api/src/main/java/com/whoz_in/main_api/command/member/application/ProfileImageDeleteHandler.java
@@ -1,0 +1,33 @@
+package com.whoz_in.main_api.command.member.application;
+
+import com.whoz_in.domain.member.MemberRepository;
+import com.whoz_in.domain.member.model.Member;
+import com.whoz_in.domain.member.model.MemberId;
+import com.whoz_in.domain.member.service.MemberFinderService;
+import com.whoz_in.main_api.command.shared.application.CommandHandler;
+import com.whoz_in.main_api.shared.application.Handler;
+import com.whoz_in.main_api.shared.utils.ImageUploadStorage;
+import com.whoz_in.main_api.shared.utils.RequesterInfo;
+import lombok.RequiredArgsConstructor;
+import org.springframework.transaction.annotation.Transactional;
+
+@Handler
+@RequiredArgsConstructor
+public class ProfileImageDeleteHandler implements CommandHandler<ProfileImageDelete, Void> {
+    private final RequesterInfo requesterInfo;
+    private final MemberFinderService memberFinderService;
+    private final MemberRepository memberRepository;
+    private final ImageUploadStorage imageUploadStorage;
+
+
+    @Transactional
+    @Override
+    public Void handle(ProfileImageDelete cmd) {
+        MemberId requesterId = requesterInfo.getMemberId();
+        Member member = memberFinderService.find(requesterId);
+        imageUploadStorage.delete(member.getProfileImageId());
+        member.setDefaultProfileImage();
+        memberRepository.save(member);
+        return null;
+    }
+}

--- a/modules/main-api/src/main/java/com/whoz_in/main_api/command/member/application/ProfileImageUpload.java
+++ b/modules/main-api/src/main/java/com/whoz_in/main_api/command/member/application/ProfileImageUpload.java
@@ -17,7 +17,7 @@ import javax.imageio.ImageIO;
 import javax.imageio.ImageReader;
 import javax.imageio.stream.ImageInputStream;
 
-public record UploadProfileImage(byte[] bytes) implements Command {
+public record ProfileImageUpload(byte[] bytes) implements Command {
     private static final int MAX_SIZE = 2 * 1024 * 1024; // 2MB
     private static final int MIN_SIZE = 1024; // 1KB
     private static final int MAX_DIMENSION = 5000; // 5000px
@@ -34,7 +34,7 @@ public record UploadProfileImage(byte[] bytes) implements Command {
             {0x23, 0x21} // 스크립트 파일 (#!)
     };
 
-    public UploadProfileImage {
+    public ProfileImageUpload {
         valideFileNotEmpty(bytes);
         validateFileSize(bytes);
         validateMaliciousSignatures(bytes);

--- a/modules/main-api/src/main/java/com/whoz_in/main_api/command/member/application/ProfileImageUploadHandler.java
+++ b/modules/main-api/src/main/java/com/whoz_in/main_api/command/member/application/ProfileImageUploadHandler.java
@@ -13,7 +13,7 @@ import org.springframework.transaction.annotation.Transactional;
 
 @Handler
 @RequiredArgsConstructor
-public class UploadProfileImageHandler implements CommandHandler<UploadProfileImage, Void> {
+public class ProfileImageUploadHandler implements CommandHandler<ProfileImageUpload, Void> {
     private final RequesterInfo requesterInfo;
     private final MemberFinderService memberFinderService;
     private final ImageUploadStorage imageUploadStorage;
@@ -22,7 +22,7 @@ public class UploadProfileImageHandler implements CommandHandler<UploadProfileIm
 
     @Transactional
     @Override
-    public Void handle(UploadProfileImage cmd) {
+    public Void handle(ProfileImageUpload cmd) {
         MemberId requesterId = requesterInfo.getMemberId();
         Member member = memberFinderService.find(requesterId);
         member.initProfileImageIdIfAbsent();

--- a/modules/main-api/src/main/java/com/whoz_in/main_api/command/member/presentation/MemberController.java
+++ b/modules/main-api/src/main/java/com/whoz_in/main_api/command/member/presentation/MemberController.java
@@ -7,8 +7,9 @@ import com.whoz_in.main_api.command.member.application.LogOut;
 import com.whoz_in.main_api.command.member.application.LoginSuccessTokens;
 import com.whoz_in.main_api.command.member.application.MemberOAuth2Login;
 import com.whoz_in.main_api.command.member.application.MemberOAuth2SignUp;
+import com.whoz_in.main_api.command.member.application.ProfileImageDelete;
 import com.whoz_in.main_api.command.member.application.Reissue;
-import com.whoz_in.main_api.command.member.application.UploadProfileImage;
+import com.whoz_in.main_api.command.member.application.ProfileImageUpload;
 import com.whoz_in.main_api.command.member.presentation.docs.MemberCommandApi;
 import com.whoz_in.main_api.command.shared.application.CommandBus;
 import com.whoz_in.main_api.command.shared.presentation.CommandController;
@@ -27,6 +28,7 @@ import jakarta.servlet.http.HttpServletResponse;
 import java.io.IOException;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.DeleteMapping;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestParam;
@@ -92,9 +94,15 @@ public class MemberController extends CommandController implements MemberCommand
   @Override
   @PostMapping("/api/v1/members/image")
   public ResponseEntity<SuccessBody<Void>> upload(@RequestParam("image") MultipartFile file) throws IOException {
-    UploadProfileImage cmd = new UploadProfileImage(file.getBytes());
+    ProfileImageUpload cmd = new ProfileImageUpload(file.getBytes());
     dispatch(cmd);
     return ResponseEntityGenerator.success("프로필 이미지 업로드 성공", HttpStatus.CREATED);
+  }
+
+  @DeleteMapping("/api/v1/members/image")
+  public ResponseEntity<SuccessBody<Void>> deleteProfileImage(ProfileImageDelete request) {
+    dispatch(request);
+    return ResponseEntityGenerator.success("기본 프로필 이미지 적용 성공", HttpStatus.OK);
   }
 
   private void removeTokenCookies(HttpServletResponse response) {

--- a/modules/main-api/src/main/java/com/whoz_in/main_api/command/member/presentation/MemberController.java
+++ b/modules/main-api/src/main/java/com/whoz_in/main_api/command/member/presentation/MemberController.java
@@ -90,7 +90,7 @@ public class MemberController extends CommandController implements MemberCommand
   }
 
   @Override
-  @PostMapping("/api/v1/members/images")
+  @PostMapping("/api/v1/members/image")
   public ResponseEntity<SuccessBody<Void>> upload(@RequestParam("image") MultipartFile file) throws IOException {
     UploadProfileImage cmd = new UploadProfileImage(file.getBytes());
     dispatch(cmd);

--- a/modules/main-api/src/main/java/com/whoz_in/main_api/command/member/presentation/MemberController.java
+++ b/modules/main-api/src/main/java/com/whoz_in/main_api/command/member/presentation/MemberController.java
@@ -100,8 +100,8 @@ public class MemberController extends CommandController implements MemberCommand
   }
 
   @DeleteMapping("/api/v1/members/image")
-  public ResponseEntity<SuccessBody<Void>> deleteProfileImage(ProfileImageDelete request) {
-    dispatch(request);
+  public ResponseEntity<SuccessBody<Void>> deleteProfileImage() {
+    dispatch(new ProfileImageDelete());
     return ResponseEntityGenerator.success("기본 프로필 이미지 적용 성공", HttpStatus.OK);
   }
 

--- a/modules/main-api/src/main/java/com/whoz_in/main_api/config/WebMvcConfig.java
+++ b/modules/main-api/src/main/java/com/whoz_in/main_api/config/WebMvcConfig.java
@@ -28,7 +28,7 @@ public class WebMvcConfig implements WebMvcConfigurer {
 
     @Override
     public void addResourceHandlers(ResourceHandlerRegistry registry) {
-        registry.addResourceHandler("/api/v1/members/images/**")
+        registry.addResourceHandler("/images/**")
                 .addResourceLocations("file:/app/uploads/images/");
     }
 }

--- a/modules/main-api/src/main/java/com/whoz_in/main_api/config/WebMvcConfig.java
+++ b/modules/main-api/src/main/java/com/whoz_in/main_api/config/WebMvcConfig.java
@@ -7,6 +7,7 @@ import lombok.RequiredArgsConstructor;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.web.method.support.HandlerMethodArgumentResolver;
 import org.springframework.web.servlet.config.annotation.InterceptorRegistry;
+import org.springframework.web.servlet.config.annotation.ResourceHandlerRegistry;
 import org.springframework.web.servlet.config.annotation.WebMvcConfigurer;
 
 @Configuration
@@ -23,5 +24,11 @@ public class WebMvcConfig implements WebMvcConfigurer {
     @Override
     public void addInterceptors(InterceptorRegistry registry) {
         registry.addInterceptor(requesterLoggingInterceptor);
+    }
+
+    @Override
+    public void addResourceHandlers(ResourceHandlerRegistry registry) {
+        registry.addResourceHandler("/api/v1/members/images/**")
+                .addResourceLocations("file:/app/uploads/images/");
     }
 }

--- a/modules/main-api/src/main/java/com/whoz_in/main_api/config/security/SecurityFilterChainConfig.java
+++ b/modules/main-api/src/main/java/com/whoz_in/main_api/config/security/SecurityFilterChainConfig.java
@@ -109,7 +109,7 @@ public class SecurityFilterChainConfig {
                             "/api/v1/reissue"
                     )
                     // ssid를 기기 등록 토큰으로만 요청하는게 아니라 AT로도 요청할 수 있어야 함. 필터를 새로 만들거나 다른 방법을 생각해봐야 함
-                    .requestMatchers(HttpMethod.GET, "/api/v1/ssid");
+                    .requestMatchers(HttpMethod.GET, "/api/v1/ssid", "/api/v1/members/images/**");
         });
 
         commonConfigurations(httpSecurity);

--- a/modules/main-api/src/main/java/com/whoz_in/main_api/config/security/SecurityFilterChainConfig.java
+++ b/modules/main-api/src/main/java/com/whoz_in/main_api/config/security/SecurityFilterChainConfig.java
@@ -109,7 +109,7 @@ public class SecurityFilterChainConfig {
                             "/api/v1/reissue"
                     )
                     // ssid를 기기 등록 토큰으로만 요청하는게 아니라 AT로도 요청할 수 있어야 함. 필터를 새로 만들거나 다른 방법을 생각해봐야 함
-                    .requestMatchers(HttpMethod.GET, "/api/v1/ssid", "/api/v1/members/images/**");
+                    .requestMatchers(HttpMethod.GET, "/api/v1/ssid", "/images/**");
         });
 
         commonConfigurations(httpSecurity);

--- a/modules/main-api/src/main/java/com/whoz_in/main_api/config/security/SecurityFilterChainConfig.java
+++ b/modules/main-api/src/main/java/com/whoz_in/main_api/config/security/SecurityFilterChainConfig.java
@@ -171,7 +171,8 @@ public class SecurityFilterChainConfig {
                         "/api/v1/device/info",
                         "/api/v1/badges/members"
                 ).requestMatchers(HttpMethod.DELETE,
-                        "/api/v1/device"
+                        "/api/v1/device",
+                        "/api/v1/members/image"
                 )
         ).authorizeHttpRequests(auth-> auth.anyRequest().authenticated());
 

--- a/modules/main-api/src/main/java/com/whoz_in/main_api/config/security/SecurityFilterChainConfig.java
+++ b/modules/main-api/src/main/java/com/whoz_in/main_api/config/security/SecurityFilterChainConfig.java
@@ -166,7 +166,7 @@ public class SecurityFilterChainConfig {
                         "/api/v1/feedback/**",
                         "/api/v1/badges",
                         "/api/v1/badges/members",
-                        "/api/v1/members/images"
+                        "/api/v1/members/image"
                 ).requestMatchers(HttpMethod.PATCH,
                         "/api/v1/device/info",
                         "/api/v1/badges/members"

--- a/modules/main-api/src/main/java/com/whoz_in/main_api/query/member/application/profile/MemberProfile.java
+++ b/modules/main-api/src/main/java/com/whoz_in/main_api/query/member/application/profile/MemberProfile.java
@@ -12,6 +12,7 @@ public record MemberProfile(
         String memberName,
         String position,
         @JsonSerialize(using = HourSerializer.class)
-        Duration totalActiveTime
+        Duration totalActiveTime,
+        String profileImageUrl
 ) implements Response {
 }

--- a/modules/main-api/src/main/java/com/whoz_in/main_api/query/member/application/profile/MemberProfile.java
+++ b/modules/main-api/src/main/java/com/whoz_in/main_api/query/member/application/profile/MemberProfile.java
@@ -1,11 +1,13 @@
 package com.whoz_in.main_api.query.member.application.profile;
 
+import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.databind.annotation.JsonSerialize;
 import com.whoz_in.main_api.query.shared.application.Response;
 import com.whoz_in.main_api.query.shared.presentation.HourSerializer;
 import java.time.Duration;
 import java.util.UUID;
 
+@JsonInclude(JsonInclude.Include.NON_NULL)
 public record MemberProfile(
         UUID memberId,
         int generation,

--- a/modules/main-api/src/main/java/com/whoz_in/main_api/query/member/application/profile/MemberProfileHandler.java
+++ b/modules/main-api/src/main/java/com/whoz_in/main_api/query/member/application/profile/MemberProfileHandler.java
@@ -5,6 +5,7 @@ import com.whoz_in.main_api.query.member.application.shared.MemberInfoViewer;
 import com.whoz_in.main_api.query.member.application.shared.MemberInfoView;
 import com.whoz_in.main_api.query.shared.application.QueryHandler;
 import com.whoz_in.main_api.shared.application.Handler;
+import com.whoz_in.main_api.shared.utils.ProfileImageService;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 
@@ -14,6 +15,7 @@ import lombok.extern.slf4j.Slf4j;
 public class MemberProfileHandler implements QueryHandler<MemberProfileGet, MemberProfile> {
 
     private final MemberInfoViewer memberInfoViewer;
+    private final ProfileImageService profileImageService;
 
     @Override
     public MemberProfile handle(MemberProfileGet query) {
@@ -22,12 +24,17 @@ public class MemberProfileHandler implements QueryHandler<MemberProfileGet, Memb
                     log.warn("회원 정보 없음: memberId={}", query.memberId());
                     return NoMemberException.EXCEPTION;
                 });
+
+        // url 생성 로직이 S3 등으로 변경되면 ProfileImageService를 수정한다.
+        String profileImageUrl = profileImageService.getProfileImageUrl(memberInfoView.profileImageId().toString());
+
         return new MemberProfile(
                 memberInfoView.memberId(),
                 memberInfoView.generation(),
                 memberInfoView.name(),
                 memberInfoView.position(),
-                memberInfoView.totalActiveTime()
+                memberInfoView.totalActiveTime(),
+                profileImageUrl
         );
     }
 }

--- a/modules/main-api/src/main/java/com/whoz_in/main_api/query/member/application/profile/MemberProfileHandler.java
+++ b/modules/main-api/src/main/java/com/whoz_in/main_api/query/member/application/profile/MemberProfileHandler.java
@@ -26,7 +26,7 @@ public class MemberProfileHandler implements QueryHandler<MemberProfileGet, Memb
                 });
 
         // url 생성 로직이 S3 등으로 변경되면 ProfileImageService를 수정한다.
-        String profileImageUrl = profileImageUtil.getProfileImageUrl(memberInfoView.profileImageId().toString());
+        String profileImageUrl = profileImageUtil.getProfileImageUrl(memberInfoView.profileImageId());
 
         return new MemberProfile(
                 memberInfoView.memberId(),

--- a/modules/main-api/src/main/java/com/whoz_in/main_api/query/member/application/profile/MemberProfileHandler.java
+++ b/modules/main-api/src/main/java/com/whoz_in/main_api/query/member/application/profile/MemberProfileHandler.java
@@ -5,7 +5,7 @@ import com.whoz_in.main_api.query.member.application.shared.MemberInfoViewer;
 import com.whoz_in.main_api.query.member.application.shared.MemberInfoView;
 import com.whoz_in.main_api.query.shared.application.QueryHandler;
 import com.whoz_in.main_api.shared.application.Handler;
-import com.whoz_in.main_api.shared.utils.ProfileImageService;
+import com.whoz_in.main_api.shared.utils.ProfileImageUtil;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 
@@ -15,7 +15,7 @@ import lombok.extern.slf4j.Slf4j;
 public class MemberProfileHandler implements QueryHandler<MemberProfileGet, MemberProfile> {
 
     private final MemberInfoViewer memberInfoViewer;
-    private final ProfileImageService profileImageService;
+    private final ProfileImageUtil profileImageUtil;
 
     @Override
     public MemberProfile handle(MemberProfileGet query) {
@@ -26,7 +26,7 @@ public class MemberProfileHandler implements QueryHandler<MemberProfileGet, Memb
                 });
 
         // url 생성 로직이 S3 등으로 변경되면 ProfileImageService를 수정한다.
-        String profileImageUrl = profileImageService.getProfileImageUrl(memberInfoView.profileImageId().toString());
+        String profileImageUrl = profileImageUtil.getProfileImageUrl(memberInfoView.profileImageId().toString());
 
         return new MemberProfile(
                 memberInfoView.memberId(),

--- a/modules/main-api/src/main/java/com/whoz_in/main_api/query/member/application/shared/MemberInfoView.java
+++ b/modules/main-api/src/main/java/com/whoz_in/main_api/query/member/application/shared/MemberInfoView.java
@@ -12,7 +12,8 @@ public record MemberInfoView(
         String statusMessage,
         Duration totalActiveTime,
         String mainBadgeName,
-        String mainBadgeColor
+        String mainBadgeColor,
+        UUID profileImageId
 ) implements View {
 
 }

--- a/modules/main-api/src/main/java/com/whoz_in/main_api/query/member/presentation/MemberQueryController.java
+++ b/modules/main-api/src/main/java/com/whoz_in/main_api/query/member/presentation/MemberQueryController.java
@@ -62,5 +62,4 @@ public class MemberQueryController extends QueryController implements MemberQuer
     public ResponseEntity<SuccessBody<MemberProfile>> getProfileInfo(@PathVariable("memberId") String memberId){
         return ResponseEntityGenerator.success(ask(new MemberProfileGet(UUID.fromString(memberId))), CrudResponseCode.READ);
     }
-
 }

--- a/modules/main-api/src/main/java/com/whoz_in/main_api/shared/persistence/FailDeleteImageException.java
+++ b/modules/main-api/src/main/java/com/whoz_in/main_api/shared/persistence/FailDeleteImageException.java
@@ -1,0 +1,10 @@
+package com.whoz_in.main_api.shared.persistence;
+
+import com.whoz_in.shared.WhozinException;
+
+public class FailDeleteImageException extends WhozinException {
+  public static final FailDeleteImageException EXCEPTION = new FailDeleteImageException();
+    private FailDeleteImageException() {
+        super("6011", "이미지 삭제 실패");
+    }
+}

--- a/modules/main-api/src/main/java/com/whoz_in/main_api/shared/persistence/FailUploadImageException.java
+++ b/modules/main-api/src/main/java/com/whoz_in/main_api/shared/persistence/FailUploadImageException.java
@@ -1,4 +1,4 @@
-package com.whoz_in.main_api.command.member.exception;
+package com.whoz_in.main_api.shared.persistence;
 
 import com.whoz_in.shared.WhozinException;
 

--- a/modules/main-api/src/main/java/com/whoz_in/main_api/shared/persistence/FileSystemImageUploadStorage.java
+++ b/modules/main-api/src/main/java/com/whoz_in/main_api/shared/persistence/FileSystemImageUploadStorage.java
@@ -42,6 +42,10 @@ public class FileSystemImageUploadStorage implements ImageUploadStorage {
 
     @Override
     public void delete(ProfileImageId profileImageId) {
+        if (profileImageId == null) {
+            return;
+        }
+
         try {
             String imgId = profileImageId.id().toString();
             Path imageFilePath = Paths.get(uploadFolder, imgId + "." + OUTPUT_FORMAT);

--- a/modules/main-api/src/main/java/com/whoz_in/main_api/shared/persistence/FileSystemImageUploadStorage.java
+++ b/modules/main-api/src/main/java/com/whoz_in/main_api/shared/persistence/FileSystemImageUploadStorage.java
@@ -1,7 +1,6 @@
 package com.whoz_in.main_api.shared.persistence;
 
 import com.whoz_in.domain.member.model.ProfileImageId;
-import com.whoz_in.main_api.command.member.exception.FailUploadImageException;
 import com.whoz_in.main_api.shared.utils.ImageUploadStorage;
 import java.io.ByteArrayInputStream;
 import java.io.ByteArrayOutputStream;
@@ -38,6 +37,18 @@ public class FileSystemImageUploadStorage implements ImageUploadStorage {
 
         } catch (IOException e) {
             throw FailUploadImageException.EXCEPTION;
+        }
+    }
+
+    @Override
+    public void delete(ProfileImageId profileImageId) {
+        try {
+            String imgId = profileImageId.id().toString();
+            Path imageFilePath = Paths.get(uploadFolder, imgId + "." + OUTPUT_FORMAT);
+
+            Files.deleteIfExists(imageFilePath);
+        } catch (IOException e) {
+            throw FailDeleteImageException.EXCEPTION;
         }
     }
 

--- a/modules/main-api/src/main/java/com/whoz_in/main_api/shared/utils/ImageUploadStorage.java
+++ b/modules/main-api/src/main/java/com/whoz_in/main_api/shared/utils/ImageUploadStorage.java
@@ -4,4 +4,5 @@ import com.whoz_in.domain.member.model.ProfileImageId;
 
 public interface ImageUploadStorage {
     void save(ProfileImageId profileImageId, byte[]bytes);
+    void delete(ProfileImageId profileImageId);
 }

--- a/modules/main-api/src/main/java/com/whoz_in/main_api/shared/utils/ProfileImageService.java
+++ b/modules/main-api/src/main/java/com/whoz_in/main_api/shared/utils/ProfileImageService.java
@@ -1,0 +1,26 @@
+package com.whoz_in.main_api.shared.utils;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+@Service
+@RequiredArgsConstructor
+public class ProfileImageService {
+
+    private static final String IMAGE_BASE_URL = "/images/";
+    private static final String DEFAULT_IMAGE_URL = "/images/default.png";
+    private static final String IMAGE_EXTENSION = ".jpg";
+
+    /**
+     * 프로필 이미지 URL 반환
+     * @param profileImageId 회원 프로필 이미지 ID
+     * @return 이미지 URL
+     */
+    public String getProfileImageUrl(String profileImageId) {
+        if (profileImageId == null || profileImageId.isBlank()) {
+            return DEFAULT_IMAGE_URL;
+        }
+
+        return IMAGE_BASE_URL + profileImageId + IMAGE_EXTENSION;
+    }
+}

--- a/modules/main-api/src/main/java/com/whoz_in/main_api/shared/utils/ProfileImageUtil.java
+++ b/modules/main-api/src/main/java/com/whoz_in/main_api/shared/utils/ProfileImageUtil.java
@@ -5,7 +5,7 @@ import org.springframework.stereotype.Service;
 
 @Service
 @RequiredArgsConstructor
-public class ProfileImageService {
+public class ProfileImageUtil {
 
     private static final String IMAGE_BASE_URL = "/images/";
     private static final String DEFAULT_IMAGE_URL = "/images/default.png";

--- a/modules/main-api/src/main/java/com/whoz_in/main_api/shared/utils/ProfileImageUtil.java
+++ b/modules/main-api/src/main/java/com/whoz_in/main_api/shared/utils/ProfileImageUtil.java
@@ -1,5 +1,6 @@
 package com.whoz_in.main_api.shared.utils;
 
+import java.util.UUID;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 
@@ -16,8 +17,8 @@ public class ProfileImageUtil {
      * @param profileImageId 회원 프로필 이미지 ID
      * @return 이미지 URL
      */
-    public String getProfileImageUrl(String profileImageId) {
-        if (profileImageId == null || profileImageId.isBlank()) {
+    public String getProfileImageUrl(UUID profileImageId) {
+        if (profileImageId == null) {
             return DEFAULT_IMAGE_URL;
         }
 

--- a/modules/main-api/src/main/java/com/whoz_in/main_api/shared/utils/ProfileImageUtil.java
+++ b/modules/main-api/src/main/java/com/whoz_in/main_api/shared/utils/ProfileImageUtil.java
@@ -9,7 +9,6 @@ import org.springframework.stereotype.Service;
 public class ProfileImageUtil {
 
     private static final String IMAGE_BASE_URL = "/images/";
-    private static final String DEFAULT_IMAGE_URL = "/images/default.png";
     private static final String IMAGE_EXTENSION = ".jpg";
 
     /**
@@ -19,7 +18,7 @@ public class ProfileImageUtil {
      */
     public String getProfileImageUrl(UUID profileImageId) {
         if (profileImageId == null) {
-            return DEFAULT_IMAGE_URL;
+            return null;
         }
 
         return IMAGE_BASE_URL + profileImageId + IMAGE_EXTENSION;


### PR DESCRIPTION
## 📌 관련 이슈

close #335 

## ✨ PR 내용

- 프로필 이미지 삭제

도커 볼륨에서 회원의 프로필 이미지를 삭제하고 member의 profileImageId를 null로 설정해주었습니다.

- 프로필 이미지 조회

회원 프로필 조회 API에 추가하였습니다.


| 프로필 이미지가 존재할 때 | profileImageId가 null일 때 |
|------------------|-----------------|
| <img width="300" src="https://github.com/user-attachments/assets/c8dca137-98a3-4410-b431-9733882744a6" /> | <img width="300" src="https://github.com/user-attachments/assets/65c7542e-b5f6-45f6-9258-1164497f1150" /> |


## 🤓 리뷰어에게

다음과 같이 이미지를 불러올 수 있습니다!

<img width="500" height="150" alt="image" src="https://github.com/user-attachments/assets/da28dcf7-85ce-4c97-b602-3645571f30d2" />

ㅤ

- 참고사항

<img width="500" height="462" alt="image" src="https://github.com/user-attachments/assets/3122435d-9dec-45df-b064-fce66a36ecf4" />


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- New Features
  - 프로필 이미지 삭제 API 추가: DELETE /api/v1/members/image (삭제 성공 응답 포함)
  - 프로필 이미지 업로드 경로 통일: POST /api/v1/members/image (기존 /api/v1/members/images 대체)
  - 정적 이미지 제공 및 공개 접근 허용: GET /images/** 로 이미지 접근 가능
  - 회원 프로필 응답에 profileImageUrl 추가(기본/사용자 이미지 URL 제공)

- Bug Fixes
  - 프로필 이미지가 없는 경우 발생하던 예외 예방 및 안정성 향상 (이미지 처리·삭제 신뢰성 개선)
<!-- end of auto-generated comment: release notes by coderabbit.ai -->