### PR TITLE
[FEAT] ETag와 Last-Modified를 통한 이미지 변경사항 검사

### DIFF
--- a/modules/main-api/src/main/java/com/whoz_in/main_api/config/WebMvcConfig.java
+++ b/modules/main-api/src/main/java/com/whoz_in/main_api/config/WebMvcConfig.java
@@ -2,13 +2,19 @@ package com.whoz_in.main_api.config;
 
 import com.whoz_in.main_api.shared.presentation.TokenArgumentResolver;
 import com.whoz_in.main_api.shared.presentation.logging.RequesterLoggingInterceptor;
+import jakarta.servlet.Filter;
 import java.util.List;
+import java.util.concurrent.TimeUnit;
 import lombok.RequiredArgsConstructor;
+import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
+import org.springframework.http.CacheControl;
+import org.springframework.web.filter.ShallowEtagHeaderFilter;
 import org.springframework.web.method.support.HandlerMethodArgumentResolver;
 import org.springframework.web.servlet.config.annotation.InterceptorRegistry;
 import org.springframework.web.servlet.config.annotation.ResourceHandlerRegistry;
 import org.springframework.web.servlet.config.annotation.WebMvcConfigurer;
+import org.springframework.web.servlet.resource.PathResourceResolver;
 
 @Configuration
 @RequiredArgsConstructor
@@ -29,6 +35,14 @@ public class WebMvcConfig implements WebMvcConfigurer {
     @Override
     public void addResourceHandlers(ResourceHandlerRegistry registry) {
         registry.addResourceHandler("/images/**")
-                .addResourceLocations("file:/app/uploads/images/");
+                .addResourceLocations("file:/app/uploads/images/")
+                .setCacheControl(CacheControl.maxAge(1, TimeUnit.DAYS))
+                .resourceChain(true)
+                .addResolver(new PathResourceResolver());
+    }
+
+    @Bean
+    public Filter shallowEtagHeaderFilter() {
+        return new ShallowEtagHeaderFilter();
     }
 }

--- a/modules/main-api/src/main/java/com/whoz_in/main_api/config/WebMvcConfig.java
+++ b/modules/main-api/src/main/java/com/whoz_in/main_api/config/WebMvcConfig.java
@@ -36,7 +36,7 @@ public class WebMvcConfig implements WebMvcConfigurer {
     public void addResourceHandlers(ResourceHandlerRegistry registry) {
         registry.addResourceHandler("/images/**")
                 .addResourceLocations("file:/app/uploads/images/")
-                .setCacheControl(CacheControl.maxAge(1, TimeUnit.DAYS))
+                .setCacheControl(CacheControl.noCache().cachePublic().mustRevalidate())
                 .resourceChain(true)
                 .addResolver(new PathResourceResolver());
     }


### PR DESCRIPTION
## 📌 관련 이슈

closes #340 

## ✨ PR 내용

이미지 조회 시 변경사항이 없을 경우 304 응답을 반환하도록 하였습니다. 

## 🤓 리뷰어에게

프로필 조회 API에서의 profime_image_url 응답을 가지고 `https://<서버주소> + profile_image_url` 형식으로 브라우저에서 이미지를 조회할 수 있습니다.

예: `http://localhost:2470/images/e7a1b969-bbbc-4746-a89b-6a30ada5f1fa.jpg`

이미지 조회에 대한 응답으로 Response Header에서 ETag값과 Last-Modified값을 받을 수 있습니다. 

정적 리소스로 위처럼 이미지를 조회할 때 

- ETag를 통한 재검사하는 경우, 클라이언트에서 `If-None-Match` 헤더에 ETag값을 넣어 요청합니다.
- Last-Modified를 통한 재검사하는 경우, 클라이언트에서 `If-Modified-Since` 헤더를 사용합니다.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* 신기능
  * 정적 이미지 리소스에 대한 캐싱과 ETag 지원을 추가했습니다. 이제 브라우저가 최대 1일 동안 캐시를 활용하며, 변경사항이 없는 경우 304 Not Modified 응답을 통해 로딩 속도가 빨라지고 데이터 사용량이 줄어듭니다.
  * 애플리케이션 전역으로 ETag 헤더 필터가 적용되어 중복 전송을 최소화하고, 이미지 등 정적 자산의 응답 효율을 개선했습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->