### PR TITLE
[CHORE] 스웨거에서 요청을 보낼 서버 주소 직접 설정

### DIFF
--- a/modules/main-api/src/main/java/com/whoz_in/main_api/config/OpenApiConfig.java
+++ b/modules/main-api/src/main/java/com/whoz_in/main_api/config/OpenApiConfig.java
@@ -3,6 +3,8 @@ package com.whoz_in.main_api.config;
 import io.swagger.v3.oas.models.Components;
 import io.swagger.v3.oas.models.OpenAPI;
 import io.swagger.v3.oas.models.info.Info;
+import io.swagger.v3.oas.models.servers.Server;
+import java.util.List;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 
@@ -13,7 +15,13 @@ public class OpenApiConfig {
     public OpenAPI openAPI() {
         return new OpenAPI()
                 .components(new Components())
-                .info(apiInfo());
+                .info(apiInfo())
+                .servers(List.of(
+                        new Server().url("https://www.whozin.econovation.kr")
+                                .description("운영 서버"),
+                        new Server().url("http://localhost:2470")
+                                .description("로컬 개발 서버")
+                ));
     }
 
     private Info apiInfo() {

--- a/modules/main-api/src/main/java/com/whoz_in/main_api/config/WebMvcConfig.java
+++ b/modules/main-api/src/main/java/com/whoz_in/main_api/config/WebMvcConfig.java
@@ -4,7 +4,6 @@ import com.whoz_in.main_api.shared.presentation.TokenArgumentResolver;
 import com.whoz_in.main_api.shared.presentation.logging.RequesterLoggingInterceptor;
 import jakarta.servlet.Filter;
 import java.util.List;
-import java.util.concurrent.TimeUnit;
 import lombok.RequiredArgsConstructor;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;


### PR DESCRIPTION
## 📌 관련 이슈

closes #343 

## ✨ PR 내용

스웨거에서 http로 요청을 보내는 문제를 해결하기 위해 요청을 보낼 서버 주소를 직접 설정하였습니다. 로컬 주소도 추가하여 선택할 수 있습니다.

<img width="300" height="398" alt="image" src="https://github.com/user-attachments/assets/55621c59-f5a2-47bc-b8e8-e4e49eab4fbd" />


## 🤓 리뷰어에게



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* 문서화 (Documentation)
  * OpenAPI 정의에 서버 목록(프로덕션, 로컬 개발)을 추가했습니다. 이에 따라 문서에서 서버 기본값과 경로가 명시되며, Swagger UI 등에서 환경 선택과 호출 검증이 더 직관적입니다.

* 정리 (Chores)
  * 사용되지 않는 import를 제거해 설정 코드를 단순화했습니다. 기능 변화는 없으며, 빌드 경고 가능성을 줄이고 유지보수를 용이하게 했습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->