### PR TITLE
[FEAT] 기기 삭제 시 기기 소유자 확인

### DIFF
--- a/modules/domain/src/main/java/com/whoz_in/domain/device/model/Device.java
+++ b/modules/domain/src/main/java/com/whoz_in/domain/device/model/Device.java
@@ -28,7 +28,7 @@ public final class Device extends AggregateRoot {
     private final Set<DeviceInfo> deviceInfos;
     @Getter @Nullable private LocalDateTime deactivatedAt;
 
-    public boolean isDeactivated() {
+    private boolean isDeactivated() {
         return deactivatedAt != null;
     }
 

--- a/modules/main-api/src/main/java/com/whoz_in/main_api/command/device/application/DeviceRemoveHandler.java
+++ b/modules/main-api/src/main/java/com/whoz_in/main_api/command/device/application/DeviceRemoveHandler.java
@@ -3,6 +3,8 @@ package com.whoz_in.main_api.command.device.application;
 import com.whoz_in.domain.device.DeviceRepository;
 import com.whoz_in.domain.device.model.Device;
 import com.whoz_in.domain.device.service.DeviceFinderService;
+import com.whoz_in.domain.device.service.DeviceOwnershipService;
+import com.whoz_in.domain.member.model.MemberId;
 import com.whoz_in.domain.member.service.MemberFinderService;
 import com.whoz_in.domain.shared.event.EventBus;
 import com.whoz_in.main_api.command.shared.application.CommandHandler;
@@ -19,12 +21,15 @@ public class DeviceRemoveHandler implements CommandHandler<DeviceRemove, Void> {
     private final DeviceRepository deviceRepository;
     private final DeviceFinderService deviceFinderService;
     private final EventBus eventBus;
+    private final DeviceOwnershipService deviceOwnershipService;
+
 
     @Transactional
     @Override
     public Void handle(DeviceRemove command) {
-        memberFinderService.mustExist(requesterInfo.getMemberId());
+        MemberId memberId = requesterInfo.getMemberId();
         Device device = deviceFinderService.find(command.getDeviceId());
+        deviceOwnershipService.validateIsMine(device,memberId);
         device.deactivate();
         deviceRepository.save(device);
         eventBus.publish(device.pullDomainEvents());


### PR DESCRIPTION
## 📌 관련 이슈

closes #345 

## ✨ PR 내용

기존에 있었던 `DeviceOwnershipService`를 가지고 기기 삭제 요청 시에 기기 소유자 확인을 수행합니다. 

기기 소유자가 자신의 기기를 올바르게 삭제 요청을 보냈을 경우, 정상적으로 수행됩니다. 만약 자신의 기기가 아닌 기기 삭제에 대한 요청이 오면 해당 기기의 주인에 대한 정보를 담아 예외 메시지를 반환합니다.

```
{
    "generated_at": "2025-09-22T15:59:46",
    "error_code": "3020",
    "message": "이 기기는 윤석호 회원의 기기입니다. 해당 회원에게 기기 삭제를 부탁하세요."
}
```

## 🤓 리뷰어에게



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Features
  - 기기 삭제 시 소유자 검증을 추가하여 본인 소유 기기만 삭제되도록 처리
  - 삭제 요청 처리 흐름을 정리하고 일관된 응답 반환

- Refactor
  - 내부 메서드의 접근 제어를 강화하여 모듈 캡슐화를 개선

<!-- end of auto-generated comment: release notes by coderabbit.ai -->